### PR TITLE
use MasterKey if provided by developer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,12 +50,8 @@ export default class App {
         json[key] = payload[key];
       }
     }
-    if (options.useMasterKey) {
-      if (this._MasterKey) {
-        json._MasterKey = this._MasterKey;
-      } else {
-        throw new Error('Cannot use the master key. It has not been provided.');
-      }
+    if (this._MasterKey) {
+      json._MasterKey = this._MasterKey;
     }
     if (options.sessionToken) {
       json._SessionToken = options.sessionToken;


### PR DESCRIPTION
Disabled check of `options.useMasterKey`. It can be used automatically if developer provides `masterKey` while initialising `new App`.

Please see -> #5 